### PR TITLE
个人使用后的几点改动

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 CHATGPT_SESSION_TOKEN=''
+
+botName = 'arXiv'
+roomWhiteList = ['群名称']
+aliasWhiteList = ['备注名', '李四']

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,1 @@
 CHATGPT_SESSION_TOKEN=''
-
-botName = 'arXiv'
-roomWhiteList = ['群名称']
-aliasWhiteList = ['备注名', '李四']

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 WechatEveryDay.memory-card.json
 .env
 test.js
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ WechatEveryDay.memory-card.json
 .env
 test.js
 package-lock.json
+config.js

--- a/config.js.example
+++ b/config.js.example
@@ -2,10 +2,10 @@
 export const botWechatName = 'arXiv'
 
 // 定义机器人的名称，这里是为了防止群聊消息太多，所以只有艾特机器人才会回复，
-export const botName_ = '小G'
+export const botName = '小G'
 
 // 群聊白名单，白名单内的群聊才会自动回复
-export const roomWhiteList_ = ['群名称']
+export const roomWhiteList = ['群名称']
 
 // 联系人白名单，白名单内的联系人才会自动回复
-export const aliasWhiteList_ = ['备注名', '李四']
+export const aliasWhiteList = ['备注名', '李四']

--- a/config.js.example
+++ b/config.js.example
@@ -1,5 +1,8 @@
+// 真实微信名
+export const botWechatName = 'arXiv'
+
 // 定义机器人的名称，这里是为了防止群聊消息太多，所以只有艾特机器人才会回复，
-export const botName_ = 'arXiv'
+export const botName_ = '小G'
 
 // 群聊白名单，白名单内的群聊才会自动回复
 export const roomWhiteList_ = ['群名称']

--- a/config.js.example
+++ b/config.js.example
@@ -1,0 +1,3 @@
+export const botName_ = 'arXiv'
+export const roomWhiteList_ = ['群名称']
+export const aliasWhiteList_ = ['备注名', '李四']

--- a/config.js.example
+++ b/config.js.example
@@ -1,3 +1,8 @@
+// 定义机器人的名称，这里是为了防止群聊消息太多，所以只有艾特机器人才会回复，
 export const botName_ = 'arXiv'
+
+// 群聊白名单，白名单内的群聊才会自动回复
 export const roomWhiteList_ = ['群名称']
+
+// 联系人白名单，白名单内的联系人才会自动回复
 export const aliasWhiteList_ = ['备注名', '李四']

--- a/src/wechaty/sendMessage.js
+++ b/src/wechaty/sendMessage.js
@@ -1,13 +1,17 @@
 import { getChatGPTReply } from '../chatgpt/index.js'
-import dotenv from 'dotenv'
+import { botName_, roomWhiteList_, aliasWhiteList_ } from '../../config.js'
 
 // 定义机器人的名称，这里是为了防止群聊消息太多，所以只有艾特机器人才会回复，
 // TODO 记得修改成你自己的微信名称 ↓
-const botName = dotenv.config().parsed.botName
+const botName = botName_
 // 群聊白名单，白名单内的群聊才会自动回复
-const roomWhiteList = dotenv.config().parsed.roomWhiteList
+const roomWhiteList = roomWhiteList_
 // 联系人白名单，白名单内的联系人才会自动回复
-const aliasWhiteList = dotenv.config().parsed.aliasWhiteList.concat([botName])
+const aliasWhiteList = aliasWhiteList_.concat([botName])
+
+console.log(botName)
+console.log(roomWhiteList)
+console.log(aliasWhiteList)
 
 /**
  * 默认消息发送
@@ -24,13 +28,13 @@ export async function defaultMessage(msg, bot) {
   let roomName = (await room?.topic()) || null // 群名称
   const alias = (await contact.alias()) || (await contact.name()) // 发消息人昵称
   const isText = msg.type() === bot.Message.Type.Text // 消息类型是否为文本
-  const isRoom = roomWhiteList.includes(roomName) && RegExp(`^@${botName}\s+`).test(content) // 是否在群聊白名单内并且艾特了机器人
+  const isRoom = roomWhiteList.includes(roomName) && RegExp(`^@${botName} `).test(content) // 是否在群聊白名单内并且艾特了机器人
   const isAlias = aliasWhiteList.includes(alias) && RegExp(`^${botName}`).test(content) // 是否在联系人白名单内且提到机器人
 
   // TODO 你们可以根据自己的需求修改这里的逻辑
   if (isText && ((!isRoom && isAlias) || isRoom)) {
     console.log('🚀🚀🚀 / content', content)
-    let reply = await getChatGPTReply(content.replace(RegExp(`^${botName}\s*`), ''))
+    let reply = await getChatGPTReply(content.replace(RegExp(`^@?${botName}\s*`), ''))
     console.log('🤖🤖🤖 / reply', reply)
     try {
       // 区分群聊和私聊

--- a/src/wechaty/sendMessage.js
+++ b/src/wechaty/sendMessage.js
@@ -28,10 +28,9 @@ export async function defaultMessage(msg, bot) {
   let roomName = (await room?.topic()) || null // 群名称
   const alias = (await contact.alias()) || (await contact.name()) // 发消息人昵称
   const isText = msg.type() === bot.Message.Type.Text // 消息类型是否为文本
-  const isRoom = roomWhiteList.includes(roomName) && RegExp(`^@${botName} `).test(content) // 是否在群聊白名单内并且艾特了机器人
+  const isRoom = roomWhiteList.includes(roomName) && RegExp(`^@${botName}`).test(content) // 是否在群聊白名单内并且艾特了机器人
   const isAlias = aliasWhiteList.includes(alias) && RegExp(`^${botName}`).test(content) // 是否在联系人白名单内且提到机器人
 
-  // TODO 你们可以根据自己的需求修改这里的逻辑
   if (isText && ((!isRoom && isAlias) || isRoom)) {
     console.log('🚀🚀🚀 / content', content)
     let reply = await getChatGPTReply(content.replace(RegExp(`^@?${botName}\s*`), ''))

--- a/src/wechaty/sendMessage.js
+++ b/src/wechaty/sendMessage.js
@@ -1,14 +1,7 @@
 import { getChatGPTReply } from '../chatgpt/index.js'
-import { botName_, roomWhiteList_, aliasWhiteList_, botWechatName } from '../../config.js'
+import { botName, roomWhiteList, aliasWhiteList, botWechatName } from '../../config.js'
 
-// 定义机器人的名称，这里是为了防止群聊消息太多，所以只有艾特机器人才会回复，
-// TODO 记得修改成你自己的微信名称 ↓
-const botName = botName_
-// 群聊白名单，白名单内的群聊才会自动回复
-const roomWhiteList = roomWhiteList_
-// 联系人白名单，白名单内的联系人才会自动回复
-const aliasWhiteList = aliasWhiteList_ //.concat([botWechatName])
-
+console.log(botWechatName)
 console.log(botName)
 console.log(roomWhiteList)
 console.log(aliasWhiteList)
@@ -30,12 +23,13 @@ export async function defaultMessage(msg, bot) {
   const isText = msg.type() === bot.Message.Type.Text // 消息类型是否为文本
   const isRoom = roomWhiteList.includes(roomName) && RegExp(`^@${botName}`).test(content) // 是否在群聊白名单内并且艾特了机器人
   const isAlias = aliasWhiteList.includes(alias) && RegExp(`^${botName}`).test(content) // 是否在联系人白名单内且提到机器人
-  const isBotSelf =
-    alias == botWechatName && aliasWhiteList.includes((await receiver.alias()) || (await receiver.name())) && RegExp(`^${botName}`).test(content) // 发送方为机器人微信号，接收方在白名单内
+  const isBotSelf = room
+    ? false
+    : alias == botWechatName && aliasWhiteList.includes((await receiver.alias()) || (await receiver.name())) && RegExp(`^${botName}`).test(content) // 发送方为机器人微信号，接收方在白名单内
 
   if (isText && ((!isRoom && (isAlias || isBotSelf)) || isRoom)) {
     console.log('🚀🚀🚀 / content', content)
-    let reply = '我好像运行崩溃了'
+    let reply = '我好像运行崩溃了🥲'
     try {
       reply = await getChatGPTReply(content.replace(RegExp(`^@?${botName}\s*`), ''))
     } catch (e) {
@@ -45,12 +39,12 @@ export async function defaultMessage(msg, bot) {
     try {
       // 区分群聊和私聊
       if (room) {
+        // Room chat
         await room.say(reply)
       } else {
-        // 私人聊天，白名单内的直接发送
-
-        // in case of answer loop
+        // personal chat
         if (RegExp(`^${botName}`).test(reply)) {
+          // in case of answer loop
           reply = ' ' + reply
         }
 


### PR DESCRIPTION
- 获取 ChatGPT 返回时可能会报错（网络之类的问题吧），用 `try catch` 包起来了，失败的话发送失败信息（避免对着微信傻等），~~重试 ChatGPT 返回还没做~~
- 允许机器人微信触发关键词提问 ChatGPT，此时对信息接受方 `say`。（使用者只有一个微信号又想在私聊中提问 ChatGPT 的场景）
- 把白名单与名称配置项独立开来。dotenv 对列表处理不是很好，所以粗暴的新建一个 `config.js` 作为 walkaround 了。（配了 example）
- 允许触发关键词 (`botName`) 与微信名 (`botWechatName`) 不同
- `content` 的触发用正则做了严格一点的限制，一定是在文本开头，且群聊是有 `@`。私聊就不用了（毕竟因为私聊长按头像只自动输入了微信名）

以上是我的一些改动，看看作者是否觉得合理/有需要 :)