### PR TITLE
Passing executablePath via CHROME_BIN

### DIFF
--- a/src/wechaty/index.js
+++ b/src/wechaty/index.js
@@ -50,12 +50,14 @@ async function onMessage(msg) {
 }
 
 // 初始化机器人
+const CHROME_BIN = process.env.CHROME_BIN ? { endpoint: process.env.CHROME_BIN } : {}
 export const bot = WechatyBuilder.build({
   name: 'WechatEveryDay',
   // puppet: 'wechaty-puppet-wechat4u', // 如果有token，记得更换对应的puppet
   puppet: 'wechaty-puppet-wechat', // 如果 wechaty-puppet-wechat 存在问题，也可以尝试使用上面的 wechaty-puppet-wechat4u ，记得安装 wechaty-puppet-wechat4u
   puppetOptions: {
     uos: true,
+    ...CHROME_BIN
   },
 })
 


### PR DESCRIPTION
@wangrongding , related to issue https://github.com/wangrongding/wechat-bot/issues/54. I want to set the same environment variable "CHROME_BIN" as in "puppet", we can pass the chrome bin path dynamically without changing the code.

Example:
```bash
export CHROME_BIN="/usr/bin/chromium"
# export CHROME_BIN="./node_module/puppeteer/xxxx/.../chromium-linux/chromium"
npm run dev
```

How do you think?