### PR TITLE
Enhance Dockerfile & Add Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
-FROM debian:bullseye
+ARG APT_SOURCE="default"
 
+FROM node:19 as builder-default
+ENV NPM_REGISTRY="https://registry.npmjs.org"
+
+FROM node:19 as builder-aliyun
+
+ENV NPM_REGISTRY="https://registry.npmmirror.com"
+RUN sed -i s/deb.debian.org/mirrors.aliyun.com/g /etc/apt/sources.list \
+    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
+
+FROM builder-${APT_SOURCE} AS builder
 # Instal the 'apt-utils' package to solve the error 'debconf: delaying package configuration, since apt-utils is not installed'
 # https://peteris.rocks/blog/quiet-and-unattended-installation-with-apt-get/
 RUN apt-get update \
@@ -31,16 +41,16 @@ RUN apt-get update \
   && apt-get purge --auto-remove \
   && rm -rf /tmp/* /var/lib/apt/lists/*
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get update && apt-get install -y --no-install-recommends nodejs \
-    && apt-get purge --auto-remove \
-    && rm -rf /tmp/* /var/lib/apt/lists/*
+FROM builder
+
+ENV CHROME_BIN="/usr/bin/chromium" \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 
 RUN mkdir -p /app
 WORKDIR /app
 
 COPY package.json ./
-RUN npm i
+RUN npm config set registry ${NPM_REGISTRY} && npm i
 
 COPY *.js ./
 COPY src/ ./src/

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,45 @@
+ARG APT_SOURCE="default"
+
+FROM node:19-alpine as base
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache bash \
+      ca-certificates \
+      chromium-chromedriver \
+      chromium \
+      coreutils \
+      curl \
+      ffmpeg \
+      figlet \
+      jq \
+      moreutils \
+      ttf-freefont \
+      udev \
+      vim \
+      xauth \
+      xvfb \
+    && rm -rf /tmp/* /var/cache/apk/*
+
+
+FROM base as builder-default
+ENV NPM_REGISTRY="https://registry.npmjs.org"
+
+FROM base as builder-aliyun
+ENV NPM_REGISTRY="https://registry.npmmirror.com"
+
+
+FROM builder-${APT_SOURCE}
+
+ENV CHROME_BIN="/usr/bin/chromium-browser" \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY package.json ./
+RUN npm config set registry ${NPM_REGISTRY} && npm i
+
+COPY *.js ./
+COPY src/ ./src/
+
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
Relate to https://github.com/wangrongding/wechat-bot/issues/94 

This PR has below changes:
+ Refactor Dockerfile
+ Optimizes the size of the Docker image
+ Optimizes image build time
+ Supporting switch to ALIYUN sources
+ Support node alpine image

---
Image Size:
```
REPOSITORY   TAG              IMAGE ID       CREATED        SIZE
wechat-bot   node-19-alpine   2b1c50d9a116   3 hours ago    844MB
wechat-bot   node-19          c46390dfe3d8   5 hours ago    1.95GB
```

---
Usage:

```bash
# APT_SOURCE supports `default` and `aliyun`
docker build -t wechat-bot:node-19 --build-arg APT_SOURCE="aliyun" .
docker build -t wechat-bot:node-19-alpine -f Dockerfile.alpine --build-arg APT_SOURCE="aliyun" .
```
