### PR TITLE
更新Claude模型配置，添加CLAUDE_BASE_URL环境变量

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,7 +82,8 @@ TONGYI_MODEL='qwen-plus'
 # claude
 CLAUDE_API_VERSION = '2023-06-01'
 CLAUDE_API_KEY = ''
-CLAUDE_MODEL = 'claude-3-5-sonnet-latest'
+CLAUDE_MODEL = 'claude-sonnet-4-5-20250929'
+CLAUDE_BASE_URL = 'https://api.anthropic.com/v1/messages'
 # 系统人设
 CLAUDE_SYSTEM = ''
 

--- a/src/claude/index.js
+++ b/src/claude/index.js
@@ -3,8 +3,35 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 const env = dotenv.config().parsed
+
+/**
+ * 用于规整env文件中配置的url到标准格式
+ */
+function normalizeClaudeBaseUrl(url) {
+  if (!url) {
+    return 'https://api.anthropic.com/v1/messages'
+  }
+  
+  let normalizedUrl = url.replace(/\/$/, '')
+  
+  if (normalizedUrl.includes('/v1/messages')) {
+    return normalizedUrl
+  }
+  
+  if (normalizedUrl.includes('/v1') && !normalizedUrl.includes('/messages')) {
+    return `${normalizedUrl}/messages`
+  }
+  
+  if (normalizedUrl.includes('/messages') && !normalizedUrl.includes('/v1')) {
+    return normalizedUrl.replace('/messages', '/v1/messages')
+  }
+  
+  return `${normalizedUrl}/v1/messages`
+}
+
 const key = env.CLAUDE_API_KEY || ''
 const model = env.CLAUDE_MODEL ? env.CLAUDE_MODEL : 'claude-3-5-sonnet-latest'
+const baseUrl = normalizeClaudeBaseUrl(env.CLAUDE_BASE_URL)  
 const system = env.CLAUDE_SYSTEM || ''
 const apiVersion = env.CLAUDE_API_VERSION || '2023-06-01'
 
@@ -25,7 +52,7 @@ function claudeConfig(prompt) {
   }
   return {
     method: 'post',
-    url: 'https://api.anthropic.com/v1/messages',
+    url: baseUrl,
     headers: {
       'x-api-key': key,
       'anthropic-version': apiVersion,


### PR DESCRIPTION
1. 支持在配置文件里配置CLAUDE_BASE_URL，方便用Claude国内中转服务的使用
2. Claude默认配置的Sonnet更新到4.5